### PR TITLE
fix: 동행자 모집 페이지 국기 아이콘 이미지 경로 수정

### DIFF
--- a/src/pages/CompanionBoard.vue
+++ b/src/pages/CompanionBoard.vue
@@ -51,19 +51,28 @@ const list = ref([])
 const totalPages = ref(1)
 const loading = ref(false)
 
+import koreaFlag from '@/assets/icons/companion/flag_Korea.svg'
+import japanFlag from '@/assets/icons/companion/flag_Japan.png'
+import chinaFlag from '@/assets/icons/companion/flag_China.png'
+import germanyFlag from '@/assets/icons/companion/flag_Germany.png'
+import franceFlag from '@/assets/icons/companion/flag_France.png'
+import vietnamFlag from '@/assets/icons/companion/flag_Vietnam.png'
+import usaFlag from '@/assets/icons/companion/flag_USA.png'
+
 const countryFlagMap = {
-  국내: 'flag_Korea.svg',
-  일본: 'flag_Japan.png',
-  중국: 'flag_China.png',
-  독일: 'flag_Germany.png',
-  프랑스: 'flag_France.png',
-  베트남: 'flag_Vietnam.png',
-  미국: 'flag_USA.png',
+  국내: koreaFlag,
+  일본: japanFlag,
+  중국: chinaFlag,
+  독일: germanyFlag,
+  프랑스: franceFlag,
+  베트남: vietnamFlag,
+  미국: usaFlag,
 }
 
-const countryFlagUrl = computed(
-  () => `/src/assets/icons/companion/${countryFlagMap[country.value] || 'flag_default.png'}`,
-)
+const countryFlagUrl = computed(() => {
+  const flag = countryFlagMap[country.value]
+  return flag ?? ''  // 플래그 없으면 빈 문자열
+})
 
 function formatPeriod(start, end) {
   return `${start} ~ ${end}`


### PR DESCRIPTION
## 💻 변경 사항

- 기존에 문자열로 지정했던 국기 이미지 경로(`/src/assets/...`)를 import 방식으로 수정
- Vite 빌드 시 이미지가 자동으로 포함되지 않는 문제를 해결하여, CloudFront + S3 배포 후 이미지 엑박 이슈 해결
- #41

## 🛠️ 수정 이유

- 배포 환경에서 `/src/assets/...` 경로는 실제 존재하지 않기 때문에 이미지가 표시되지 않았습니다.

## 😀 개선 방법
- `import` 방식으로 처리 시 Vite가 해당 이미지를 빌드 결과물에 포함시켜 S3에서 접근 가능할 것으로 생각됩니다.

closes #41