### PR TITLE
Feat: text component 생성

### DIFF
--- a/src/components/Text/Card.vue
+++ b/src/components/Text/Card.vue
@@ -1,0 +1,17 @@
+<template>
+  <p class="card-text">
+    <slot></slot>
+  </p>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/mixins' as m;
+@use '@/styles/variables' as v;
+
+.card-text {
+  font-size: 0.875rem;
+  color: #f9f7f7;
+  line-height: 100%;
+  letter-spacing: 0%;
+}
+</style>

--- a/src/components/Text/Comment.vue
+++ b/src/components/Text/Comment.vue
@@ -1,0 +1,17 @@
+<template>
+  <p class="comment-text">
+    <slot></slot>
+  </p>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/mixins' as m;
+@use '@/styles/variables' as v;
+
+.comment-text {
+  font-size: 1rem;
+  color: #666666;
+  line-height: 100%;
+  letter-spacing: 0%;
+}
+</style>

--- a/src/components/Text/Paragraph_16.vue
+++ b/src/components/Text/Paragraph_16.vue
@@ -1,0 +1,17 @@
+<template>
+  <p class="paragraph-text">
+    <slot></slot>
+  </p>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/mixins' as m;
+@use '@/styles/variables' as v;
+
+.paragraph-text {
+  font-size: 1rem;
+  color: v.$color-accent;
+  line-height: 100%;
+  letter-spacing: 0%;
+}
+</style>

--- a/src/components/Text/Paragraph_18.vue
+++ b/src/components/Text/Paragraph_18.vue
@@ -1,0 +1,17 @@
+<template>
+  <p class="paragraph-text">
+    <slot></slot>
+  </p>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/mixins' as m;
+@use '@/styles/variables' as v;
+
+.paragraph-text {
+  font-size: 1.125rem;
+  color: v.$color-accent;
+  line-height: 100%;
+  letter-spacing: 0%;
+}
+</style>

--- a/src/components/Text/Title.vue
+++ b/src/components/Text/Title.vue
@@ -1,0 +1,18 @@
+<template>
+  <p class="title-text">
+    <slot></slot>
+  </p>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/mixins' as m;
+@use '@/styles/variables' as v;
+
+.title-text {
+  font-size: 1.5rem;
+  color: v.$color-accent;
+  font-weight: bold;
+  line-height: 100%;
+  letter-spacing: 0%;
+}
+</style>


### PR DESCRIPTION
✅ 작업 개요
반복적으로 사용되는 텍스트 스타일을 컴포넌트로 분리하여, 코드의 재사용성과 유지보수성을 향상시켰습니다.
각 텍스트 유형에 따라 별도의 컴포넌트로 구성하여, UI 전반의 일관성을 확보할 수 있도록 하였습니다.


🧩 추가된 텍스트 컴포넌트 및 스타일 정보
Title : 24px #3F72AF bold
Paragraph_18 : 18px #3F72AF
Paragraph_16 : 16px #3F72AF
Comment : 16px #666666
Card : 14px #F9F7F7

📜 작업위치
src/components/Text/Title.vue
src/components/Text/Paragraph_18.vue
src/components/Text/Paragraph_16.vue
src/components/Text/Comment.vue
src/components/Text/Card.vue

😀 참고
- Title 글씨: src/components/Text/Title.vue
→ 각 페이지의 제목 글씨 / 게시글 제목

- Card 글씨: src/components/Text/Card.vue
→ 카드 안의 흰색 글씨

- Comment 글씨: src/components/Text/Comment.vue
→ 게시판 페이지 댓글 글씨 / 메인 패키지 설명 글 / 소제목

- 본문 글씨: src/components/Text/Paragraph_16.vue
→ 각 페이지의 본문 글씨 / 게시물 리스트

- 본문 글씨: src/components/Text/Paragraph_18.vue
→ 각 페이지의 본문 글씨 / 게시글