### PR TITLE
feat: BaseText 생성

### DIFF
--- a/src/components/Base/BaseText.vue
+++ b/src/components/Base/BaseText.vue
@@ -1,0 +1,33 @@
+<template>
+  <component :is="tag" :class="['dynamic-text', { bold }]" :style="textStyle">
+    <slot></slot>
+  </component>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  tag: { type: String, default: 'p' },
+  color: { type: String, default: '--color-primary' },
+  size: { type: String, default: '--fs-body' },
+  bold: { type: Boolean, default: false },
+  lineHeight: { type: String, default: '100%' },
+  letterSpacing: { type: String, default: '0%' },
+})
+
+const textStyle = computed(() => ({
+  color: `var(${props.color})`,
+  fontSize: `var(${props.size})`,
+  fontWeight: props.bold ? 'var(--fw-bold)' : 'var(--fw-regular)',
+  lineHeight: props.lineHeight,
+  letterSpacing: props.letterSpacing,
+  fontFamily: 'var(--font-family)',
+}))
+</script>
+
+<style scoped>
+.dynamic-text {
+  margin: 0;
+}
+</style>


### PR DESCRIPTION
✅ 작업 개요
반복적으로 사용되는 텍스트 스타일을 컴포넌트로 분리하여, 코드의 재사용성과 유지보수성을 향상시켰습니다.
각 텍스트 유형에 따라 별도의 컴포넌트로 구성하여, UI 전반의 일관성을 확보할 수 있도록 하였습니다.

🔧 주요 기능
- tag: 렌더링할 HTML 태그 지정 (p, span, h1 등)
- color: CSS 변수 형태로 색상 지정 (기본값: --color-primary)
- size: 폰트 크기 지정 (기본값: --fs-body)
- bold: 굵기 여부 설정 (Boolean, 기본값: false)
- lineHeight, letterSpacing: 줄간격 및 자간 설정 가능
- scoped style로 기본 마진 제거

📌 사용 예시
- variables.css 의 변수를 props값으로 사용
`<BaseText size="--fs-title" bold color="--color-primary">
  제목 텍스트입니다.
</BaseText>`

📝 비고
디자인 시스템에 맞춰 var(--*) 형태의 CSS 변수를 사용하는 방식으로 스타일 일관성을 유지했습니다.