### PR TITLE
feat: BaseButton에 로그인 페이지에서 사용할 버튼 추가 구현 (#57)

### DIFF
--- a/src/components/Base/BaseButton.vue
+++ b/src/components/Base/BaseButton.vue
@@ -12,7 +12,7 @@
 import { computed } from 'vue'
 
 const props = defineProps({
-  size: { type: String, default: 'md', validator: (v) => ['sm', 'md', 'lg'].includes(v) },
+  size: { type: String, default: 'md', validator: (v) => ['sm', 'md', 'lg', 'xl'].includes(v) },
   disabled: { type: Boolean, default: false },
 })
 
@@ -22,6 +22,7 @@ const sizeClass = computed(
       sm: 'btn-sm',
       md: 'btn-md',
       lg: 'btn-lg',
+      xl: 'btn-xl',
     })[props.size],
 )
 </script>
@@ -63,4 +64,10 @@ const sizeClass = computed(
   width: var(--btn-lg);
   font-size: var(--fs-button-lg);
 }
+.btn-xl {
+  width: var(--btn-xl);
+  font-size: var(--fs-button-xl);
+  height: var(--btn-height-xl);
+}
+
 </style>

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -17,6 +17,7 @@
   --fs-body: 1rem; /* 16px (본문 + 게시글 제목 포함) */
   --fs-button-sm: 0.875rem; /* 14px (sm, md 공용) */
   --fs-button-lg: 1rem; /* 16px */
+  --fs-button-xl: 0.875rem; /* 로그인 버튼에 쓰는 버튼 폰트 사이즈 */
   --fs-comment: 1rem; /* 댓글 텍스트 (16px) */
 
   /* 폰트 굵기 */
@@ -47,15 +48,19 @@
   /* 버튼 */
   --btn-bg: #3f72af;
   --btn-bg-disabled: #dbe2ef;
-  --btn-text: #dbe2ef;
+  --btn-text: #f9f7f7;
   --btn-text-disabled: #3f72af;
   --btn-radius: 1rem;
   --btn-height: 2rem;
+  --btn-height-xl: 2.5rem;
   --btn-gap: 0.25rem;
 
   --btn-sm: 6.5rem;
   --btn-md: 7.5rem;
   --btn-lg: 9rem;
+  --btn-xl: 20rem;
+  
+  
 
   /* 인풋 */
   --input-bg: #dbe2ef;


### PR DESCRIPTION
## 🥇 구현 내용

BaseButton에 로그인 페이지에서 사용할 버튼 추가 구현
fs: 14px;
button size(xl): 320 * 40

나머지는 공통 부분입니다.
```
<BaseButton size="xl">로그인</BaseButton>
```
## 참고
![image](https://github.com/user-attachments/assets/81e5044a-73b0-426d-9c5f-c3ec8b19e1a1)
