### PR TITLE
feat: 페이지네이션 SCSS 제거 및 전체 페이지 수 렌더링 오류 수정(#67)

### DIFF
--- a/src/components/Base/Pagination.vue
+++ b/src/components/Base/Pagination.vue
@@ -31,43 +31,39 @@ function goToPage(page) {
 </script>
 
 <style scoped>
-.pagination {
-  display: flex;
-  justify-content: center;
-  gap: 1rem;
-  font-size: 17px;
+.pagination{
+  display:flex;
+  justify-content:center;
+  gap:var(--space-md);
+  font-size:1.0625rem;
+  user-select:none;
+}
 
-  button {
-    all: unset;
-    color: #3f72af;
-    font-size: 18px;
-    cursor: pointer;
-    padding: 0 4px;
-    transition: color 0.2s ease-in-out;
+.pagination > button{
+  all:unset;
+  font-size:1.125rem;
+  color:var(--color-primary);
+  cursor:pointer;
+  padding-inline:4px;
+  transition:color .2s ease-in-out;
+}
+.pagination > button:hover:not(:disabled){
+  color:#112d4e;
+}
+.pagination > button:disabled{
+  cursor:default; opacity:.4;
+}
 
-    &:hover:not(:disabled) {
-      color: #112d4e;
-    }
-
-    &:disabled {
-      cursor: default;
-    }
-  }
-
-  span {
-    color: #3f72af;
-    cursor: pointer;
-    transition: color 0.2s ease-in-out;
-
-    &.active {
-      font-weight: bold;
-      color: #3f72af;
-      text-decoration: underline;
-    }
-
-    &:hover:not(.active) {
-      color: #112d4e;
-    }
-  }
+.pagination > span{
+  color:var(--color-primary);
+  cursor:pointer;
+  transition:color .2s ease-in-out;
+}
+.pagination > span.active{
+  font-weight:var(--fw-bold);
+  text-decoration:underline;
+}
+.pagination > span:hover:not(.active){
+  color:#112d4e;
 }
 </style>

--- a/src/pages/CompanionBoard.vue
+++ b/src/pages/CompanionBoard.vue
@@ -113,7 +113,7 @@ async function fetchList() {
     })
 
     list.value = Array.isArray(data.content) ? data.content : []
-    totalPages.value = data.pagination?.totalPages ?? 1
+    totalPages.value = data.pagination?.totalPageCount ?? 1
   } catch (e) {
     console.error('API 호출 실패:', e)
     list.value = []
@@ -191,7 +191,7 @@ watch(
 }
 
 .pagination {
-  margin-top: 73px;
-  margin-bottom: 86px;
+  margin-top: 4.5rem;
+  margin-bottom: 5rem;
 }
 </style>


### PR DESCRIPTION
📌 변경 이유
- Pagination.vue 컴포넌트가 SCSS 기반으로 작성되어 있어 구조 정리가 필요했음.
- 데이터를 3페이지 이상 나오도록 넣어줬음에도 CompanionBoard.vue에서 `totalPages` 값이 항상 1로 고정되는 문제 발견

✅ 작업 내용
- Pagination.vue 스타일 SCSS 제거 → CSS만 사용하는 것으로 수정
- CompanionBoard.vue의 `data.pagination.totalPages → totalPageCount`로 변경
- 전체 페이지 수 정확히 반영되도록 API 응답 구조 재확인 후 대응

closes #67 