### PR TITLE
fix: CloudFront 캐시 무효화 실패 문제 해결 (#61)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -31,6 +31,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_DISTRIBUTION: ${{ secrets.AWS_DISTRIBUTION_ID }}
+          DISTRIBUTION: ${{ secrets.AWS_DISTRIBUTION_ID }}
           PATHS: '/*'
         continue-on-error: true


### PR DESCRIPTION
- invalidate-cloudfront-action에서 요구하는 DISTRIBUTION 환경변수명 오타 수정 
-> AWS_DISTRIBUTION → DISTRIBUTION