### PR TITLE
fix: BaseDatePicker UX 및 스타일 개선 (#64)

### DIFF
--- a/src/components/Base/BaseDatePicker.vue
+++ b/src/components/Base/BaseDatePicker.vue
@@ -14,11 +14,9 @@
       <VDatePicker
         v-model="inner"
         locale="ko"
-        :masks="{ input: 'YYYY-MM-DD', title: 'M月' }"
+        :masks="{ input: 'YYYY-MM-DD', title: 'YYYY년 M월' }"
         :title-position="'in-header'"
         :show-title="true"
-        :nav-prev-icon="false"
-        :nav-next-icon="false"
         :min-date="minDate"
         :max-date="maxDate"
         @update:model-value="onDateSelected"
@@ -30,25 +28,36 @@
 <script setup>
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 
-/* ───────── props / emits ───────── */
 const props = defineProps({
-  modelValue: { type: String, default: '' }, // 'YYYY-MM-DD'
+  modelValue: { type: String, default: '' },
   placeholder: { type: String, default: '' },
   min: String,
   max: String,
 })
 const emit = defineEmits(['update:modelValue'])
 
-const inner = ref(props.modelValue ? new Date(props.modelValue) : null)
 const open = ref(false)
 const wrapper = ref(null)
 
 const minDate = computed(() => props.min || null)
 const maxDate = computed(() => props.max || null)
 
+function strToLocalDate(s){
+  if(!s) return null
+  const [y,m,d] = s.split('-').map(Number)
+  return new Date(y, m-1, d) // 로컬 날짜 객체
+}
+const inner = ref(strToLocalDate(props.modelValue))
+
+// local 'YYYY-MM-DD'
+function fmtLocal(date){
+  const pad = n => String(n).padStart(2,'0')
+  return `${date.getFullYear()}-${pad(date.getMonth()+1)}-${pad(date.getDate())}`
+}
+
 function onDateSelected(date) {
   if (!date || isNaN(date.getTime?.())) return
-  emit('update:modelValue', date.toISOString().slice(0, 10))
+  emit('update:modelValue', fmtLocal(date))
   open.value = false
 }
 
@@ -57,6 +66,9 @@ function handleClickOutside(e) {
 }
 onMounted(() => document.addEventListener('mousedown', handleClickOutside))
 onBeforeUnmount(() => document.removeEventListener('mousedown', handleClickOutside))
+
+
+
 </script>
 
 <style scoped>
@@ -70,19 +82,19 @@ input:focus {
   height: var(--btn-height);
   border-radius: var(--btn-radius);
   background: var(--color-surface);
+  display: flex;
+  align-items: center;
 }
 
 .date-icon {
   width: 1rem;
   height: 1rem;
-  margin-left: var(--space-sm);
 }
 
-/* 값/placeholder */
 .date-input {
-  flex: 1;
+  flex: 1 1 auto;
   height: 100%;
-  padding-left: 0.5rem;
+  padding-left:calc(var(--space-sm) + 1.25rem);
   border: none;
   background: transparent;
   font-size: var(--fs-body);
@@ -93,59 +105,50 @@ input:focus {
   font-weight: var(--fw-medium);
 }
 
-/* ───────── popover ───────── */
 .journey-datepicker {
   position: absolute;
-  top: calc(100% + var(--space-sm)); /* 아래 여백 8px */
+  top: calc(100% + var(--space-sm));
   left: 0;
   z-index: 9999;
   background: var(--color-surface);
   border-radius: var(--input-radius);
-  padding: var(--space-lg); /* 24px */
+  padding: var(--space-lg);
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 
-  /* v-calendar theme 토큰 덮어쓰기 */
   --vc-primary: var(--color-primary);
   --vc-accent-50: color-mix(in srgb, var(--color-primary) 12%, transparent);
   --vc-content: var(--color-primary);
 }
 
-/* v-calendar override */
 .journey-datepicker ::v-deep(.vc-container) {
   background: transparent;
   border: none;
-  box-shadow: none;
+  box-shadow: none; 
 }
+
+.journey-datepicker ::v-deep(.vc-highlight) {
+  background-color: var(--color-primary);
+}
+
 .journey-datepicker ::v-deep(.vc-nav) {
   display: flex;
   justify-content: space-between;
   margin-bottom: var(--space-sm);
 }
-.journey-datepicker ::v-deep(.vc-nav-arrow) {
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  background: color-mix(in srgb, var(--color-primary) 7%, transparent) center/18px 18px no-repeat;
+
+
+.journey-datepicker ::v-deep(.vc-title-button:hover){
+  background-color:color-mix(in srgb,var(--color-primary) 10%, transparent);
 }
-.journey-datepicker ::v-deep(.vc-nav-arrow:hover) {
-  background: color-mix(in srgb, var(--color-primary) 10%, transparent) center/18px 18px no-repeat;
-}
-.journey-datepicker ::v-deep(.vc-nav-arrow svg) {
-  display: none;
-}
-.journey-datepicker ::v-deep(.vc-nav-arrow.is-prev) {
-  background-image: url('@/assets/icons/companion/calendarPolygon3.svg');
-}
-.journey-datepicker ::v-deep(.vc-nav-arrow.is-next) {
-  background-image: url('@/assets/icons/companion/calendarPolygon3.svg');
-  transform: scaleX(-1);
-}
+
+
 .journey-datepicker ::v-deep(.vc-nav-title),
 .journey-datepicker ::v-deep(.vc-title-button) {
   color: var(--color-primary) !important;
   background: color-mix(in srgb, var(--color-primary) 7%, transparent);
+  background-color: var(--color-surface);
   font-weight: var(--fw-bold);
-  font-size: 1.25rem;
+  font-size: 1rem;
   border-radius: 6px;
   padding: 0 var(--space-sm);
 }
@@ -158,7 +161,7 @@ input:focus {
 .journey-datepicker ::v-deep(.vc-day) {
   width: 40px;
   height: 40px;
-  font-size: 1rem;
+  font-size: 1.125rem;
   color: var(--color-primary);
   line-height: 40px;
 }
@@ -173,4 +176,90 @@ input:focus {
   color: #fff;
   border-radius: 50%;
 }
+
+.journey-datepicker ::v-deep(.vc-header .vc-arrow){
+  width:30px;
+  height:30px;
+  border:none;
+  border-radius:50%;
+  background:transparent center/18px 18px no-repeat;
+  transition:background-color .15s;
+}
+.journey-datepicker ::v-deep(.vc-arrow.vc-next) {
+  background-image: url('@/assets/icons/companion/calendarPolygon3.svg');
+  transform: scaleX(-1);
+}
+
+.journey-datepicker ::v-deep(.vc-arrow.vc-prev) {
+  background-image: url('@/assets/icons/companion/calendarPolygon3.svg');
+}
+.journey-datepicker ::v-deep(.vc-header .vc-arrow:hover){
+  background-color:color-mix(in srgb,var(--color-primary) 10%, transparent);
+}
+
+.journey-datepicker ::v-deep(.vc-header .vc-arrow svg){ display:none; }
+
+.journey-datepicker ::v-deep(.vc-header .vc-title){
+  color:var(--color-primary);
+  background-color:var(--color-surface);
+  font-weight:var(--fw-bold);
+  font-size:1.25rem;
+  border-radius:6px;
+  padding:0 var(--space-sm);
+}
+.journey-datepicker ::v-deep(.vc-header .vc-title:hover){
+  background-color:color-mix(in srgb,var(--color-primary) 10%, transparent);
+}
+
+/* 월 클릭 했을 때 나오는 부분 스타일 */
+.journey-datepicker ::v-deep(.vc-popover-content) {
+  background-color: var(--color-surface);
+}
+
+.journey-datepicker ::v-deep(.vc-nav-header) {
+  background-color: var(--color-surface);
+}
+
+
+.journey-datepicker ::v-deep(.vc-nav-item .vc-focus){
+  background-color: var(--color-primary);
+}
+
+.journey-datepicker ::v-deep(.vc-nav-container .vc-focus){
+  background-color: var(--color-surface);
+}
+
+.journey-datepicker ::v-deep(.vc-nav-item.is-current) {
+  color: inherit;
+}
+
+.journey-datepicker ::v-deep(.vc-nav-item.is-active) {
+  background-color: var(--color-primary);
+  color: white;
+  border-radius: 999px;
+}
+
+.journey-datepicker ::v-deep(.vc-nav-arrow){
+  width:30px; height:30px;
+  border:none; border-radius:50%;
+  background:transparent center/18px 18px no-repeat;
+  transition:background-color .15s;
+}
+.journey-datepicker ::v-deep(.vc-nav-arrow.is-left) {
+  background-image: url('@/assets/icons/companion/calendarPolygon3.svg');
+}
+
+.journey-datepicker ::v-deep(.vc-nav-arrow.is-right) {
+  background-image: url('@/assets/icons/companion/calendarPolygon3.svg');
+  transform: scaleX(-1);
+}
+.journey-datepicker ::v-deep(.vc-nav-arrow:hover){
+  background-color:color-mix(in srgb,var(--color-primary), transparent);
+}
+.journey-datepicker ::v-deep(.vc-nav-arrow svg){ display:none; }
+.journey-datepicker ::v-deep(.vc-title-button){
+  background-color:color-mix(in srgb,var(--color-primary) 7%, transparent);
+  border:none;
+}
+
 </style>


### PR DESCRIPTION
## 📌 개요
- DatePicker 달력의 사용자 경험(UX) 및 시각적 스타일을 개선
- 선택 가능한 날짜 범위 제한 및 타이틀 가독성 향상
- 선택 상태, 호버 상태 등 디자인 시스템 기반 색상 통일
- 커스텀 SVG 화살표를 적용하여 v-calendar 기본 UI 덮어쓰기

## ✅ 작업 내역
- `min-date`, `max-date` props 사용하여 날짜 범위 제어
- `title: 'YYYY년 M월'` 설정으로 연도+월 표시
- 화살표 커스텀 아이콘 적용 및 SVG 기본 제거 (`::v-deep .vc-nav-arrow`)
- 선택된 날짜 강조 색상, 월 선택기 등 전반 스타일 개선

## 📎 관련 컴포넌트
- `BaseDatePicker.vue`

## 👀 리뷰 포인트
- 디자인 괜찮은지 확인 필요 -> `title: 'YYYY년 M월'` 설정으로 연도+월 표시

![image](https://github.com/user-attachments/assets/15cae161-701a-492c-b3a9-5299cb5b5e4e)
![image](https://github.com/user-attachments/assets/5f4b8fcb-9c83-4a11-8052-0d69c1e2c5b6)


closes #64
