### PR TITLE
라우트 가드 기능 추가 및 로그인 후 리다이렉트 처리

### DIFF
--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -60,7 +60,10 @@ import LoginForm from '@/components/Auth/LoginForm.vue'
 import IDPasswordButton from '@/components/Auth/IDPasswordButton.vue'
 import { login } from '@/api/authApi'
 import router from '@/router'
-
+import { useRoute } from 'vue-router'
+import { useAuthStore } from '@/stores/useAuthStore'
+const route = useRoute()
+const auth = useAuthStore()
 const userId = ref('')
 const password = ref('')
 const isLoading = ref(false)
@@ -73,7 +76,7 @@ const handleLogin = async () => {
   }
 
   isLoading.value = true
-  errorMessage.value = '' // 🔁 로그인 시도 전에 초기화
+  errorMessage.value = ''
 
   try {
     const response = await login({
@@ -81,10 +84,14 @@ const handleLogin = async () => {
       password: password.value,
     })
     console.log('로그인 성공:', response.data)
-    router.push('/')
+
+    await auth.fetchUser() // ✅ 로그인 후 사용자 정보 저장
+
+    const redirectPath = route.query.redirect || '/'
+    router.push(redirectPath) // ✅ 원래 가려던 곳으로 이동
   } catch (error) {
     console.error('로그인 실패:', error.response?.data || error.message)
-    errorMessage.value = '아이디 또는 비밀번호가 올바르지 않습니다.' // 🔴 에러 메시지 설정
+    errorMessage.value = '아이디 또는 비밀번호가 올바르지 않습니다.'
   } finally {
     isLoading.value = false
   }


### PR DESCRIPTION
## 🔧 작업 내용
- 라우트 가드(`router.beforeEach`)를 통해 로그인 여부를 검사하도록 구현
- 인증이 필요한 경로 접근 시 로그인 페이지로 리다이렉트
  - 로그인 후 기존에 접근하려던 경로(`to.fullPath`)로 다시 이동되도록 `query.redirect` 사용
- 로그인 페이지에서 `route.query.redirect` 값을 추출해 해당 경로로 이동 처리
- `useAuthStore`에서 `fetchUser()`로 로그인 상태 동기화

## ✅ 테스트 항목
- 비로그인 상태에서 `/community/write/:country` 접근 시 로그인 페이지로 이동되는지 확인
- 로그인 후 원래 요청했던 페이지(`/community/write/:country`)로 리다이렉트 되는지 확인

## 📁 변경 파일
- `router/index.js`: `beforeEach` 훅 추가
- `LoginPage.vue`: 로그인 후 `route.query.redirect` 처리 추가
- 기타 관련 상태(`useAuthStore` 등)는 그대로 활용

## 📝 참고
- 추후 `meta: { requiresAuth: true }` 방식으로 리팩토링 가능
- 소셜 로그인 콜백에서도 리다이렉트 연동 고려 필요