### PR TITLE
[Fix] 카드 설명 영역의 하단 텍스트 잘림 및 fade 효과 개선

### DIFF
--- a/src/components/Home/TravelPackageCard.vue
+++ b/src/components/Home/TravelPackageCard.vue
@@ -112,9 +112,10 @@ function onClick() {
 
 .desc-wrapper {
   position: relative;
-  max-height: 8em;
+  max-height: 9em;
   overflow: hidden;
   margin-top: var(--space-xl);
+  background-color: var(--color-bg);
 }
 
 .desc {
@@ -123,6 +124,7 @@ function onClick() {
 
 .paragraph {
   margin-bottom: var(--space-2xl);
+  line-height: 1.4;
 }
 
 .fade-layer {
@@ -130,13 +132,17 @@ function onClick() {
   bottom: 0;
   left: 0;
   width: 100%;
-  height: 3em;
-  background: linear-gradient(to bottom, transparent, white);
+  height: 5em; /*fade 효과 범위를 줄임 */
+  background: linear-gradient(
+    to top,
+    rgba(249, 247, 247, 0.6),
+    /* 좀 더 투명하게 */ rgba(249, 247, 247, 0)
+  );
   pointer-events: none;
   z-index: 1;
 }
 
 .more_button {
-  margin-top: 3.75rem;
+  margin-top: 3rem;
 }
 </style>


### PR DESCRIPTION
## 📌 관련 이슈
Closes #141 

## 🛠 변경 사항
- desc-wrapper의 max-height를 증가
- fade-layer의 높이를 조정
- fade-layer의 background 투명도 개선
- 기존: rgba(249, 247, 247, 0.5) → 변경: rgba(249, 247, 247, 0.6) → 좀 더 부드럽고 자연스럽게 연결됨

## 💡 변경 이유
- 마지막 문단이 fade-layer에 의해 거의 완전히 가려지는 현상 발생
- 사용자가 설명을 다 읽지 못하는 UX 문제 발생
- 자연스러운 fade 효과를 유지하면서도 마지막 문장이 일부 보이도록 개선