### PR TITLE
feat: 프로필 페이지 내정보 수정 기능 추가

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,10 +24,8 @@ const hideLayout = computed(() => route.meta.hideLayout === true)
 const auth = useAuthStore()
 // onMounted 시 유저 정보 가져오기
 onMounted(async () => {
-  if (document.cookie.includes('JSESSIONID')) {
-    await auth.fetchUser()
-    console.log('🔐 현재 로그인 유저 정보:', auth.user)
-  }
+  await auth.fetchUser()
+  console.log('🔐 현재 로그인 유저 정보:', auth.user)
 })
 </script>
 

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -19,6 +19,11 @@ export const getProfileById = (memberId) => {
   return api.get(`/members/${memberId}/profile`)
 }
 
+//내 프로필 수정
+export const patchProfileById = (memberId, profileData) => {
+  return api.patch(`/members/${memberId}/profile`, profileData)
+}
+
 //여행 일정 목록
 export const getSchedulesById = (memberId) => {
   return api.get(`/members/${memberId}/plans`)
@@ -32,4 +37,16 @@ export const postSchedule = (memberId, payload) => {
 //여행 일정 삭제
 export const deleteSchedule = (planId) => {
   return api.delete(`/members/plans/${planId}`)
+}
+
+//프로필 이미지 업로드
+export const postProfileImage = (memberId, file) => {
+  const formData = new FormData()
+  formData.append('image', file)
+
+  return api.post(`/members/${memberId}/profile-image`, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  })
 }

--- a/src/components/Base/SingleDatePicker.vue
+++ b/src/components/Base/SingleDatePicker.vue
@@ -61,7 +61,7 @@ const customAttributes = computed(() => {
       return {
         key: `highlight-${idx}`,
         dates: { start, end },
-        highlight: true, 
+        highlight: true,
       }
     })
     .filter(Boolean)
@@ -105,20 +105,27 @@ input:focus {
 }
 
 .journey-datepicker {
-  position: absolute;
+  /* position: absolute; */
   top: calc(100% + var(--space-sm));
   left: 0;
-  z-index: 9999;
+  /* z-index: 9999; */
   background: var(--color-surface);
   border-radius: var(--input-radius);
-  padding: var(--space-lg);
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  padding: var(--space-md);
+
+  /* box-shadow: 0 0 10px rgba(0, 0, 0, 0.1); */
+
+  width: 22.5rem;
 
   --vc-primary: var(--color-primary);
   --vc-accent-50: color-mix(in srgb, var(--color-primary) 12%, transparent);
   --vc-content: var(--color-primary);
 }
 
+.journey-datepicker > * {
+  width: 100%;
+  height: 100%;
+}
 .journey-datepicker ::v-deep(.vc-container) {
   background: transparent;
   border: none;

--- a/src/components/Common/Editor/CommentForm.vue
+++ b/src/components/Common/Editor/CommentForm.vue
@@ -21,7 +21,7 @@
   </form>
 </template>
 <script setup>
-import { defineProps, ref } from 'vue'
+import { defineProps, ref, watch } from 'vue'
 import Avatar from '@/components/Profile/Avatar.vue'
 import BaseButton from '@/components/Base/BaseButton.vue'
 import { useRoute } from 'vue-router'

--- a/src/pages/CommunityDetail.vue
+++ b/src/pages/CommunityDetail.vue
@@ -26,8 +26,9 @@
 
     <!-- 댓글 입력 -->
     <CommentForm
+      v-if="currentUser.id"
       :nickname="currentUser.nickname"
-      :profileImageUrl="currentUser.profileImageUrl"
+      :profileImageUrl="currentUser.profileImage"
       :memberId="currentUser.id"
       :postCommentApi="postComment"
       :updateCommentApi="updateComment"
@@ -65,7 +66,7 @@ const showDeleteModal = ref(false)
 
 //로그인 유저 정보 가져오기
 const authStore = useAuthStore()
-const currentUser = computed(() => authStore.user) // 👉 currentUser로 사용
+const currentUser = computed(() => authStore.user)
 
 const fetchComments = async () => {
   const postId = route.params.id

--- a/src/pages/CompanionDetail.vue
+++ b/src/pages/CompanionDetail.vue
@@ -34,7 +34,7 @@
     <!-- 댓글 입력 -->
     <CommentForm
       :nickname="currentUser.nickname"
-      :profileImageUrl="currentUser.profileImageUrl"
+      :profileImageUrl="currentUser.profileImage"
       :memberId="currentUser.id"
       :postCommentApi="postComment"
       @commentPosted="fetchComments"

--- a/src/pages/MyProfile.vue
+++ b/src/pages/MyProfile.vue
@@ -1,8 +1,11 @@
 <!-- 마이페이지 나의 프로필 -->
 <template>
   <div class="profile-section">
-    <UserCard :profile="profile" />
-    <ScheduleManager :schedules="schedules" @refresh="fetchSchedules" />
+    <UserCard :profile="profile" @refresh="fetchProfile" />
+    <div class="schedule-row">
+      <ScheduleManager :schedules="schedules" @refresh="fetchSchedules" />
+      <SingleDatePicker :schedules="schedules" />
+    </div>
   </div>
 </template>
 
@@ -11,6 +14,7 @@ import { ref, onMounted } from 'vue'
 import { getProfileById, getSchedulesById } from '@/api/profileApi'
 import UserCard from '@/components/Profile/UserCard.vue'
 import ScheduleManager from '@/components/Profile/ScheduleManager.vue'
+import SingleDatePicker from '@/components/Base/SingleDatePicker.vue'
 
 const props = defineProps(['userId'])
 
@@ -44,5 +48,9 @@ onMounted(async () => {
   flex-direction: column; /* 세로 정렬 */
   /* gap: 2rem; /* 위아래 간격 */
   /* align-items: center; /* 가운데 정렬 (선택사항) */
+}
+.schedule-row {
+  display: flex;
+  gap: 1rem;
 }
 </style>

--- a/src/stores/useAuthStore.js
+++ b/src/stores/useAuthStore.js
@@ -68,6 +68,13 @@ export const useAuthStore = defineStore('auth', {
         console.error('로그아웃 중 오류 발생:', err)
       }
     },
+    async updateUserProfile(updatedData) {
+      // updatedData: 서버에서 수정 완료된 최신 사용자 정보 객체
+      this.user = {
+        ...this.user,
+        ...updatedData,
+      }
+    },
   },
 })
 


### PR DESCRIPTION
## 🛠️작업내용
[상세페이지]
- 게스트 유저일 시 게시글 상세 페이지에서 
   댓글 입력폼이 뜨지 않도록 처리 및 답글 버튼을 누를시 로그인 페이지로 유도

[프로필 페이지]
- 프로필 페이지 내 정보 수정 기능 추가
- 프로필 이미지 등록 
- 일정 달력 컴포넌트 렌더링

## 😢문제
- 내 정보 수정시 헤더나 프로필 popover, 댓글 입력 폼에서
  수정된 정보가 바로 반영이 안되는 문제가 있음

closes #152 
closes #151 
closes #145 