### PR TITLE
[Fix] 게시물 content에서 첫 번째 이미지 추출 및 텍스트 미리보기 수정                                       

### DIFF
--- a/src/components/Home/TodayStory.vue
+++ b/src/components/Home/TodayStory.vue
@@ -6,11 +6,11 @@
           <Avatar :profileImageUrl="each.profileImageUrl" :nickname="each.nickname" size="50px" />
         </div>
         <div class="card_body" @click="goCommunity(each.postId)">
-          <div class="image_list" v-if="each.imageUrls && each.imageUrls.length > 0">
-            <img v-for="(imgUrl, index) in each.imageUrls" :key="index" :src="imgUrl" alt="" />
+          <div class="image_list" v-if="each.firstImage">
+            <img :src="each.firstImage" alt="대표 이미지" />
           </div>
-          <div :class="['text', each.imageUrls?.length === 0 ? 'full-text' : 'clamp-text']">
-            <div v-html="each.content"></div>
+          <div :class="['text', !each.firstImage ? 'full-text' : 'clamp-text']">
+            {{ each.plainText }}
           </div>
         </div>
       </div>
@@ -30,10 +30,25 @@ const hotPosts = ref([])
 onMounted(async () => {
   try {
     const response = await mainHot({ count: 3 })
-    hotPosts.value = response.data.map((post) => ({
-      ...post,
-      time: post.createdAt ? new Date(post.createdAt) : new Date(),
-    }))
+    console.log(response)
+    hotPosts.value = response.data.map((post) => {
+      const div = document.createElement('div')
+      div.innerHTML = post.content
+
+      // 첫 번째 이미지 추출
+      const firstImg = div.querySelector('img')?.getAttribute('src') || null
+
+      // 이미지 제거 후 텍스트 추출
+      div.querySelectorAll('img').forEach((img) => img.remove())
+      const textContent = div.textContent || ''
+
+      return {
+        ...post,
+        firstImage: firstImg,
+        plainText: textContent,
+        time: post.createdAt ? new Date(post.createdAt) : new Date(),
+      }
+    })
   } catch (error) {
     console.error('HOT 게시물 불러오기 실패:', error)
   }
@@ -72,6 +87,7 @@ const goCommunity = (id) => {
   margin-bottom: var(--space-md2);
 }
 .card_body {
+  height: 235px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## 📌문제

에디터 사용할 때는 html 형식으로 서버에 보내면서 html 문서 형식 그대로 화면에 출력되는 문제 발생

## 해결 내용
- DOM API를 활용하여 each.content(HTML 문자열)에서 첫 번째 <img> 태그의 src를 추출
- 모든 <img> 태그를 제거한 후, 남은 텍스트만 추출하여 텍스트 미리보기로 사용
- 각 게시물에 `firstImage`, `plainText` 필드를 추가하여 뷰에서 이미지/텍스트 분리 렌더링 가능하도록 처리

## 변경 사항
- `onMounted` 내에서 HTML 문자열 파싱 로직 추가 (document.createElement, querySelector 등 DOM API 사용)
- 이미지가 있는 경우 첫 번째 이미지만 보여주고, 텍스트는 줄바꿈 제한(`clamp-text`)으로 노출
- 이미지가 없는 경우 전체 텍스트 표시(`full-text`)

## 결과
- 이미지와 텍스트가 혼합된 게시물 content에서 대표 이미지를 미리보기로 제공하고자 함
- 텍스트 줄 수를 적절한 길이로  제한하여 UI 안정성 개선

## 보안 고려사항 (v-html 미사용 이유)
- originally, v-html을 사용해 content를 그대로 렌더링하려 했으나,
- XSS(스크립트 삽입 공격) 등의 보안 문제가 발생할 수 있어 사용을 지양함
- 대신 DOM API로 필요한 데이터만 파싱하여 안전하게 사용함
- `<img>`는 src만 추출
- 나머지는 텍스트로 변환
- 향후 렌더링이 필요해질 경우 DOMPurify 같은 HTML sanitizer 도입 고려 가능