### PR TITLE
fix: 상세페이지에서 수정하기 누를시 초기 데이터 삽입

### DIFF
--- a/src/api/postApi.js
+++ b/src/api/postApi.js
@@ -10,3 +10,10 @@ export const getPostByPostId = (communityPostId, params = {}) => {
 export const deletePostById = (communityPostId) => {
   return api.delete(`/community/DeletePosts/${communityPostId}`)
 }
+
+//게시글 수정
+export const updatePost = (postId, formData) => {
+  return api.put(`/posts/update/${postId}`, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+}

--- a/src/components/Common/Editor/PostEditor.vue
+++ b/src/components/Common/Editor/PostEditor.vue
@@ -81,11 +81,9 @@ onMounted(async () => {
           const fd = new FormData()
           fd.append('file', blob)
 
-          const { data } = await axios.post(
-            'https://journeysite.site/api/s3/application',
-            fd,
-            { headers: { 'Content-Type': 'multipart/form-data' } },
-          )
+          const { data } = await axios.post('https://journeysite.site/api/s3/application', fd, {
+            headers: { 'Content-Type': 'multipart/form-data' },
+          })
 
           callback(data, blob.name)
         } catch (e) {
@@ -104,6 +102,20 @@ onMounted(async () => {
     }
   })
 })
+
+watch(
+  () => props.modelValue,
+  (newVal) => {
+    if (editorInstance) {
+      const currentContent = editorInstance.getHTML()
+      if (newVal !== currentContent) {
+        editorInstance.setHTML(newVal || '')
+        previewHtml.value = newVal || ''
+        checkEditorEmpty()
+      }
+    }
+  },
+)
 
 function checkEditorEmpty() {
   const html = editorInstance?.getHTML()?.trim()

--- a/src/components/Common/HotPost/HotPostItem.vue
+++ b/src/components/Common/HotPost/HotPostItem.vue
@@ -1,6 +1,6 @@
 <!-- HOT 게시글 1개 표시 -->
 <template>
-  <tr class="hot-post-row" @click="goToDetail">
+  <tr class="hot-post-row" @click="goToDetail(post.communityPostId)">
     <td id="countryText">
       [{{ post.country }}] <span id="titleText"> {{ post.title }}</span>
     </td>
@@ -17,11 +17,11 @@ const props = defineProps({
     required: true,
   },
 })
-
+console.log(props.post)
 const router = useRouter()
 
-const goToDetail = () => {
-  router.push(`/`) // 나중에 게시글 상세 페이지와 연결 필요
+const goToDetail = (postId) => {
+  router.push(`/community/${postId}`) // 나중에 게시글 상세 페이지와 연결 필요
 }
 
 const formatTime = (time) => {

--- a/src/components/Community/CountrySelectBar.vue
+++ b/src/components/Community/CountrySelectBar.vue
@@ -1,8 +1,7 @@
 <!-- 국가 버튼 탭 -->
 <template>
   <div class="country-button-group">
-    <!-- 나중에 국가별 커뮤니티 페이지로 라우팅 -->
-    <button v-for="(flag, name) in countryFlagMap" :key="name">
+    <button v-for="(flag, name) in countryFlagMap" :key="name" @click="goToCountryCommunity(name)">
       <img
         :src="getImagePath(flag)"
         class="flag-icon"
@@ -15,6 +14,10 @@
 </template>
 
 <script setup>
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
 // rem 계산 유틸 (m.rem 함수처럼)
 const rem = (px) => `${px / 16}rem`
 
@@ -34,6 +37,10 @@ const getImagePath = (filename) => {
     console.error('이미지 경로 에러:', filename, err)
     return ''
   }
+}
+
+const goToCountryCommunity = (countryName) => {
+  router.push(`/community-board/${countryName}`)
 }
 </script>
 

--- a/src/pages/CommunityDetail.vue
+++ b/src/pages/CommunityDetail.vue
@@ -88,7 +88,7 @@ onMounted(async () => {
 
 // 수정 버튼 → 수정 페이지로 이동
 const goToEditPage = () => {
-  router.push('/') //추후 작업
+  router.push(`/community/write/${route.params.id}`) //추후 작업
 }
 
 // 삭제 모달 열기/닫기

--- a/src/pages/CommunityHome.vue
+++ b/src/pages/CommunityHome.vue
@@ -9,7 +9,6 @@
 
     <div class="row1">
       <div class="text">동행자 모집</div>
-      <img src="@/assets/icons/arrow.svg" class="arrow-icon" @click="goToHotPosts" />
     </div>
 
     <div class="cards-grid">
@@ -30,7 +29,6 @@
     <div class="row1">
       <img src="@/assets/icons/hot_icon.svg" class="hot-icon" />
       <div class="text">오늘의 HOT 게시물</div>
-      <img src="@/assets/icons/arrow.svg" class="arrow-icon" @click="goToHotPosts" />
     </div>
     <hr />
 
@@ -157,7 +155,7 @@ function goToHotPosts() {
   padding: 0;
   margin: 0;
   font-size: var(--fs-title);
-  font-weight: 900;
+  font-weight: var(--fw-bold);
   color: var(--color-primary);
   height: 29px;
   line-height: 29px; /* 글자 높이 맞추기 */

--- a/src/pages/CommunityWrite.vue
+++ b/src/pages/CommunityWrite.vue
@@ -40,6 +40,8 @@ import { useRouter } from 'vue-router'
 import { useRoute } from 'vue-router'
 import axios from 'axios'
 
+import { getPostByPostId } from '@/api/postApi'
+
 const route = useRoute()
 const router = useRouter()
 const auth = useAuthStore()
@@ -47,6 +49,9 @@ const title = ref('')
 const content = ref('')
 const country = ref(decodeURIComponent(route.params.country || '국내'))
 const selectedBoard = ref(route.path.includes('/companion/write') ? 'companion' : 'community')
+
+const postId = route.params.id
+const isEditMode = !!postId
 
 const boardOptions = [
   { label: '커뮤니티', value: 'community' },
@@ -73,11 +78,25 @@ watch(selectedBoard, (newVal) => {
   }
 })
 
-onMounted(() => {
+onMounted(async () => {
   if (route.path.includes('/companion/write')) {
     selectedBoard.value = 'companion'
   } else if (route.path.includes('/community/write')) {
     selectedBoard.value = 'community'
+  }
+
+  //수정 모드일 경우 기존 게시글 불러와서 초기화
+  if (isEditMode) {
+    try {
+      const res = await getPostByPostId(postId)
+      const data = res.data
+      title.value = data.title
+      content.value = data.content
+      console.log('불러온 content:', content.value)
+      selectedBoard.value = route.path.includes('/companion') ? 'companion' : 'community'
+    } catch (e) {
+      console.error('게시글 불러오기 실패:', e)
+    }
   }
 })
 

--- a/src/pages/CompanionDetail.vue
+++ b/src/pages/CompanionDetail.vue
@@ -33,6 +33,7 @@
 
     <!-- 댓글 입력 -->
     <CommentForm
+      v-if="currentUser.id"
       :nickname="currentUser.nickname"
       :profileImageUrl="currentUser.profileImage"
       :memberId="currentUser.id"
@@ -95,7 +96,7 @@ onMounted(async () => {
 
 // 수정 버튼 → 수정 페이지로 이동
 const goToEditPage = () => {
-  router.push('/') //추후 작업
+  router.push(`/companion/write/${route.params.id}`)
 }
 
 const openDeleteModal = () => {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -68,7 +68,7 @@ const router = createRouter({
       component: CallbacNaver,
     },
     {
-      path: '/community/write/:country',
+      path: '/community/write/:id?',
       name: 'CommunityWrite',
       component: CommunityWrite,
     },
@@ -79,7 +79,7 @@ const router = createRouter({
       props: true,
     },
     {
-      path: '/companion/write/:country',
+      path: '/companion/write/:id?',
       name: 'CompanionWrite',
       component: CompanionWrite,
     },


### PR DESCRIPTION
## 🔧작업 내용
- 커뮤니티 대시보드 기존 라우팅 연결이 안되어있던 부분 해결
- 게시글 상세 페이지에서 수정하기를 누를시 
   에디터에서 기존 데이터가 초기 데이터로 삽입되도록 변경


## 추가로 해야할 작업
- 커뮤니티/동행자 작성 페이지에서 editMode일시 게시글 수정 api호출로 바꿔줘야 합니다.

closes #119 