### PR TITLE
fix: PopularDestination 반응형 그리드로 수정(#170)

### DIFF
--- a/src/components/Home/PopularDestination.vue
+++ b/src/components/Home/PopularDestination.vue
@@ -26,27 +26,29 @@ defineProps({
 <style scoped>
 .popular-container {
   display: grid;
-  grid-template-columns: repeat(3, 1fr); /* 카드 3개를 균등하게 */
-  gap: var(--space-3xl); /* 카드 사이 간격 */
-  width: 100%; /* 전체 컨테이너 너비 차지 */
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--space-3xl);
+  width: 100%;
   margin: 0 auto;
 }
 
 .banner-item {
-  width: 288px;
   position: relative;
   overflow: hidden;
   transition: transform 0.2s ease;
+  width: 100%;
+  max-width: 288px;
+  margin: 0 auto;
 }
 
 .banner-item:hover {
   transform: translateY(-0.25rem);
 }
 
-/* 이미지 채우기 */
 .banner-image img {
-  width: 288px;
-  height: 160px;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 288 / 160;
   border-radius: 16px;
   object-fit: cover;
   display: block;
@@ -56,16 +58,10 @@ defineProps({
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin: 0;
   margin-top: 11px;
-  padding: 0;
 }
 
 .icon {
-  display: inline-block;
-  vertical-align: middle;
-  margin: 0;
-  padding: 0;
   height: 16px;
   width: auto;
 }

--- a/src/pages/LoginPage.vue
+++ b/src/pages/LoginPage.vue
@@ -158,6 +158,8 @@ const goToSignup = () => {
 
 .title {
   margin-top: 9.5rem;
+  padding-left: 0 !important;
+  width: auto !important;
 }
 
 .logo {


### PR DESCRIPTION
## 📌 개요
- 인기 배너(PopularContainer) UI를 화면 너비에 따라 자동으로 조정되도록 반응형 레이아웃으로 개선

- 기존 고정형 3열 grid에서, auto-fit + minmax 방식으로 유동적인 카드 배치를 지원

## ✅ 변경 내용
### 🔧 스타일 개선
- grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)) 적용
- 카드의 width: 100%, max-width: 288px, margin: 0 auto 적용
- 이미지 비율 고정: aspect-ratio: 288 / 160
- 작은 화면에서 1열 / 중간 화면에서 2열 / 넓은 화면에서 3열 자동 구성