### PR TITLE
[fix] Divider 배너 이미지 반응형 개선 (높이 고정, 가로 축소 대응)

### DIFF
--- a/src/components/Home/DividerImage.vue
+++ b/src/components/Home/DividerImage.vue
@@ -33,10 +33,13 @@ onMounted(async () => {
   width: 100%;
   margin: 0;
   padding: 0;
+  overflow: hidden;
 }
+
 img {
   display: block;
   width: 100%;
   height: 100%;
+  object-fit: cover;
 }
 </style>


### PR DESCRIPTION
## 📌 개요
- Divider 배너 이미지가 화면 축소 시 세로까지 줄어들어 레이아웃이 깨지는 문제를 수정
- 세로는 고정(200px), 가로는 화면 크기에 맞춰 유동적으로 반응하도록 스타일을 개선

## ✅ 변경 내용
### 🔧 스타일 변경
.divider 높이 고정 유지 (height: 200px)
img에 다음 속성 적용:
width: 100%
height: 100%
object-fit: cover → 비율 유지하며 잘리는 영역은 자동 조절
display: block으로 여백 제거
overflow: hidden으로 이미지 넘침 방지

## 📂 변경 파일
components/Divider.vue

## 🧪 테스트
 PC, 태블릿, 모바일 환경에서 배너 영역 비율 유지 확인
 세로는 고정, 가로는 유동적으로 줄어드는지 확인
 이미지 왜곡 없이 자연스럽게 잘림 처리

### 🔗 관련 이슈
Closes #181